### PR TITLE
remove the last empty Array element in AmCharts.CSVToArray parse result.

### DIFF
--- a/dataloader.js
+++ b/dataloader.js
@@ -623,10 +623,19 @@ AmCharts.CSVToArray = function( strData, strDelimiter ) {
 
     }
 
-
     // Now that we have our value string, let's add
     // it to the data array.
     arrData[ arrData.length - 1 ].push( strMatchedValue );
+  }
+
+  // clear the empty or bad parsed end . csv file must has the same sequence of fields.
+  // this problem is mainly caused by the last delimiter,many program,like libreoffice export csv with LF at the end line.
+  try{
+    if( arrData[arrData.length-1].length!=arrData[arrData.length-2].length){
+        arrData.pop();
+    }
+  }catch (e){
+    //    console.log("the last data is not array,or there is only one element in arrData.");
   }
 
   // Return the parsed data.


### PR DESCRIPTION
i only modified dataloader.js ,do not modified  dataloader.min.js . 
    this problem is mainly caused by the last delimiter,many program,like libreoffice export csv with LF at the last end line.

the CSV in dataloader's examples is ended like this 

> Date,Open,High,Low,Close,Volume,Adj Close  LF
> 2000-01-04,113.56,117.12,112.25,112.62,54119000,40.86 LF
> 2000-01-03,117.38,118.62,112.00,116.56,53228400,42.29

but csv file exported by  some program like libreoffice is ended in this form

> Date,Open,High,Low,Close,Volume,Adj Close LF
> 2000-01-04,113.56,117.12,112.25,112.62,54119000,40.86 LF
> 2000-01-03,117.38,118.62,112.00,116.56,53228400,42.29 LF

so in this case dataloader will genarate a element like [""] in the end of the array(arrData). This will lead incorrect data display at later processs.
